### PR TITLE
feat(dx): Add dev server control script with start/stop/status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -203,3 +203,6 @@ logs/
 
 # Claude Code
 .claude/settings.local.json
+
+# Dev server control
+.dev-server.pid

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,10 +42,33 @@ nvc-ragbot/
 ## Development Commands
 
 ```bash
-npm run dev          # Start development server
+npm run dev          # Start development server (foreground)
 npm run build        # Build for production
 npm run test         # Run tests
 npm run lint         # Run ESLint
+```
+
+### Dev Server Control
+
+Manage the development server with these commands:
+
+```bash
+npm run dev:start    # Start server in background
+npm run dev:stop     # Stop the server
+npm run dev:status   # Check if server is running
+npm run dev:restart  # Restart the server
+npm run dev:logs     # View server logs
+```
+
+Or use the script directly:
+
+```bash
+./scripts/dev-server.sh start           # Start in foreground
+./scripts/dev-server.sh start --background  # Start in background
+./scripts/dev-server.sh stop            # Stop server
+./scripts/dev-server.sh status          # Check status
+./scripts/dev-server.sh logs            # View logs
+./scripts/dev-server.sh test            # Run tests
 ```
 
 ## Technology Stack

--- a/__tests__/scripts/dev-server.test.ts
+++ b/__tests__/scripts/dev-server.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Dev Server Control Tests
+ *
+ * Tests the dev server management scripts:
+ * - Start/stop/status/test commands
+ * - PID file management
+ * - Process lifecycle
+ *
+ * TDD: RED phase - these tests define expected behavior
+ */
+
+import { execSync, exec } from 'child_process'
+import * as fs from 'fs'
+import * as path from 'path'
+
+const PROJECT_ROOT = path.resolve(__dirname, '../..')
+const SCRIPT_PATH = path.join(PROJECT_ROOT, 'scripts', 'dev-server.sh')
+const PID_FILE = path.join(PROJECT_ROOT, '.dev-server.pid')
+
+// Helper to run script commands
+function runScript(command: string): string {
+  try {
+    return execSync(`bash ${SCRIPT_PATH} ${command}`, {
+      cwd: PROJECT_ROOT,
+      encoding: 'utf-8',
+      timeout: 10000
+    }).trim()
+  } catch (error: any) {
+    return error.stdout?.toString().trim() || error.message
+  }
+}
+
+// Helper to check if script exists and is executable
+function scriptExists(): boolean {
+  try {
+    fs.accessSync(SCRIPT_PATH, fs.constants.X_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+// Clean up before/after tests
+function cleanup() {
+  // Remove PID file if exists
+  try {
+    if (fs.existsSync(PID_FILE)) {
+      const pid = fs.readFileSync(PID_FILE, 'utf-8').trim()
+      try {
+        process.kill(parseInt(pid), 'SIGTERM')
+      } catch {
+        // Process may not exist
+      }
+      fs.unlinkSync(PID_FILE)
+    }
+  } catch {
+    // Ignore cleanup errors
+  }
+}
+
+describe('Dev Server Control Script', () => {
+  beforeAll(() => {
+    cleanup()
+  })
+
+  afterAll(() => {
+    cleanup()
+  })
+
+  describe('script setup', () => {
+    it('script file exists at scripts/dev-server.sh', () => {
+      expect(fs.existsSync(SCRIPT_PATH)).toBe(true)
+    })
+
+    it('script is executable', () => {
+      expect(scriptExists()).toBe(true)
+    })
+  })
+
+  describe('help command', () => {
+    it('displays usage information with no arguments', () => {
+      const output = runScript('')
+      expect(output).toContain('Usage:')
+      expect(output).toContain('start')
+      expect(output).toContain('stop')
+      expect(output).toContain('status')
+    })
+
+    it('displays help with --help flag', () => {
+      const output = runScript('--help')
+      expect(output).toContain('Usage:')
+    })
+  })
+
+  describe('status command', () => {
+    beforeEach(() => {
+      cleanup()
+    })
+
+    it('reports not running when no PID file exists', () => {
+      const output = runScript('status')
+      expect(output.toLowerCase()).toContain('not running')
+    })
+
+    it('reports not running when PID file has stale PID', () => {
+      // Write a fake PID that doesn't exist
+      fs.writeFileSync(PID_FILE, '99999999')
+      const output = runScript('status')
+      expect(output.toLowerCase()).toContain('not running')
+    })
+  })
+
+  describe('start command', () => {
+    afterEach(() => {
+      cleanup()
+    })
+
+    it('creates PID file when starting', () => {
+      // Start in background, don't wait for server to be ready
+      runScript('start --background')
+
+      // Give it a moment to create PID file
+      execSync('sleep 1')
+
+      expect(fs.existsSync(PID_FILE)).toBe(true)
+    })
+
+    it('writes valid PID to file', () => {
+      runScript('start --background')
+      execSync('sleep 1')
+
+      const pidContent = fs.readFileSync(PID_FILE, 'utf-8').trim()
+      const pid = parseInt(pidContent)
+
+      expect(pid).toBeGreaterThan(0)
+      expect(Number.isInteger(pid)).toBe(true)
+    })
+
+    it('reports already running if server is running', () => {
+      runScript('start --background')
+      execSync('sleep 1')
+
+      const output = runScript('start --background')
+      expect(output.toLowerCase()).toContain('already running')
+    })
+  })
+
+  describe('stop command', () => {
+    beforeEach(() => {
+      cleanup()
+    })
+
+    it('reports not running when nothing to stop', () => {
+      const output = runScript('stop')
+      expect(output.toLowerCase()).toContain('not running')
+    })
+
+    it('removes PID file after stopping', () => {
+      runScript('start --background')
+      execSync('sleep 1')
+
+      runScript('stop')
+      execSync('sleep 1')
+
+      expect(fs.existsSync(PID_FILE)).toBe(false)
+    })
+
+    it('confirms server stopped', () => {
+      runScript('start --background')
+      execSync('sleep 1')
+
+      const output = runScript('stop')
+      expect(output.toLowerCase()).toContain('stopped')
+    })
+  })
+
+  describe('restart command', () => {
+    afterEach(() => {
+      cleanup()
+    })
+
+    it('restarts the server', () => {
+      runScript('start --background')
+      execSync('sleep 1')
+
+      const oldPid = fs.readFileSync(PID_FILE, 'utf-8').trim()
+
+      runScript('restart')
+      execSync('sleep 2')
+
+      const newPid = fs.readFileSync(PID_FILE, 'utf-8').trim()
+
+      // New PID should be different
+      expect(newPid).not.toBe(oldPid)
+    })
+  })
+
+  describe('test command', () => {
+    it('runs jest tests', () => {
+      // Just verify the command exists and attempts to run tests
+      // We don't want to run the full test suite inside tests
+      const output = runScript('test --help')
+      // Should either show jest help or our script's test info
+      expect(output).toBeDefined()
+    })
+  })
+
+  describe('logs command', () => {
+    afterEach(() => {
+      cleanup()
+    })
+
+    it('shows log file path', () => {
+      const output = runScript('logs')
+      expect(output).toContain('log')
+    })
+  })
+})
+
+describe('npm script integration', () => {
+  it('package.json has dev:start script', () => {
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(PROJECT_ROOT, 'package.json'), 'utf-8')
+    )
+    expect(packageJson.scripts['dev:start']).toBeDefined()
+  })
+
+  it('package.json has dev:stop script', () => {
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(PROJECT_ROOT, 'package.json'), 'utf-8')
+    )
+    expect(packageJson.scripts['dev:stop']).toBeDefined()
+  })
+
+  it('package.json has dev:status script', () => {
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(PROJECT_ROOT, 'package.json'), 'utf-8')
+    )
+    expect(packageJson.scripts['dev:status']).toBeDefined()
+  })
+
+  it('package.json has dev:restart script', () => {
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(PROJECT_ROOT, 'package.json'), 'utf-8')
+    )
+    expect(packageJson.scripts['dev:restart']).toBeDefined()
+  })
+})

--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "private": true,
   "scripts": {
     "dev": "NODE_OPTIONS='--dns-result-order=ipv4first' next dev",
+    "dev:start": "./scripts/dev-server.sh start --background",
+    "dev:stop": "./scripts/dev-server.sh stop",
+    "dev:status": "./scripts/dev-server.sh status",
+    "dev:restart": "./scripts/dev-server.sh restart",
+    "dev:logs": "./scripts/dev-server.sh logs",
     "build": "next build",
     "build:with-seed": "next build && npm run seed",
     "start": "next start",

--- a/scripts/dev-server.sh
+++ b/scripts/dev-server.sh
@@ -1,0 +1,244 @@
+#!/bin/bash
+#
+# Dev Server Control Script
+#
+# Manages the NVC RAGbot development server lifecycle.
+# Usage: ./scripts/dev-server.sh [command]
+#
+# Commands:
+#   start      Start the development server (foreground)
+#   start --background  Start in background
+#   stop       Stop the development server
+#   restart    Restart the development server
+#   status     Check if server is running
+#   test       Run the test suite
+#   logs       Show server logs
+#   help       Show this help message
+#
+
+set -e
+
+# Configuration
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+PID_FILE="$PROJECT_ROOT/.dev-server.pid"
+LOG_FILE="$PROJECT_ROOT/.dev-server.log"
+PORT="${PORT:-3000}"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Print colored output
+print_status() {
+    echo -e "${BLUE}[NVC RAGbot]${NC} $1"
+}
+
+print_success() {
+    echo -e "${GREEN}✓${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}✗${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}!${NC} $1"
+}
+
+# Check if server is running
+is_running() {
+    if [ -f "$PID_FILE" ]; then
+        local pid=$(cat "$PID_FILE")
+        if ps -p "$pid" > /dev/null 2>&1; then
+            return 0
+        fi
+    fi
+    return 1
+}
+
+# Get the current PID
+get_pid() {
+    if [ -f "$PID_FILE" ]; then
+        cat "$PID_FILE"
+    fi
+}
+
+# Start the server
+cmd_start() {
+    local background=false
+
+    # Check for --background flag
+    if [ "$1" == "--background" ]; then
+        background=true
+    fi
+
+    if is_running; then
+        local pid=$(get_pid)
+        print_warning "Server is already running (PID: $pid)"
+        return 0
+    fi
+
+    print_status "Starting development server on port $PORT..."
+
+    cd "$PROJECT_ROOT"
+
+    if [ "$background" = true ]; then
+        # Start in background
+        nohup npm run dev > "$LOG_FILE" 2>&1 &
+        local pid=$!
+        echo "$pid" > "$PID_FILE"
+        print_success "Server started in background (PID: $pid)"
+        print_status "Logs: $LOG_FILE"
+        print_status "View logs: ./scripts/dev-server.sh logs"
+    else
+        # Start in foreground
+        print_status "Press Ctrl+C to stop"
+        npm run dev
+    fi
+}
+
+# Stop the server
+cmd_stop() {
+    if ! is_running; then
+        print_warning "Server is not running"
+        # Clean up stale PID file
+        rm -f "$PID_FILE"
+        return 0
+    fi
+
+    local pid=$(get_pid)
+    print_status "Stopping server (PID: $pid)..."
+
+    # Send SIGTERM first
+    kill "$pid" 2>/dev/null || true
+
+    # Wait for process to stop
+    local count=0
+    while ps -p "$pid" > /dev/null 2>&1 && [ $count -lt 10 ]; do
+        sleep 1
+        count=$((count + 1))
+    done
+
+    # Force kill if still running
+    if ps -p "$pid" > /dev/null 2>&1; then
+        print_warning "Force stopping..."
+        kill -9 "$pid" 2>/dev/null || true
+    fi
+
+    rm -f "$PID_FILE"
+    print_success "Server stopped"
+}
+
+# Restart the server
+cmd_restart() {
+    print_status "Restarting server..."
+    cmd_stop
+    sleep 1
+    cmd_start --background
+}
+
+# Check server status
+cmd_status() {
+    if is_running; then
+        local pid=$(get_pid)
+        print_success "Server is running (PID: $pid)"
+        print_status "Port: $PORT"
+        print_status "URL: http://localhost:$PORT"
+        return 0
+    else
+        print_warning "Server is not running"
+        # Clean up stale PID file
+        rm -f "$PID_FILE"
+        return 1
+    fi
+}
+
+# Run tests
+cmd_test() {
+    print_status "Running tests..."
+    cd "$PROJECT_ROOT"
+    npm test "$@"
+}
+
+# Show logs
+cmd_logs() {
+    if [ -f "$LOG_FILE" ]; then
+        print_status "Log file: $LOG_FILE"
+        print_status "Last 50 lines:"
+        echo "---"
+        tail -50 "$LOG_FILE"
+    else
+        print_warning "No log file found at $LOG_FILE"
+        print_status "Start server with --background to create logs"
+    fi
+}
+
+# Show help
+cmd_help() {
+    echo "NVC RAGbot Dev Server Control"
+    echo ""
+    echo "Usage: $0 [command] [options]"
+    echo ""
+    echo "Commands:"
+    echo "  start              Start the development server (foreground)"
+    echo "  start --background Start the server in background"
+    echo "  stop               Stop the development server"
+    echo "  restart            Restart the development server"
+    echo "  status             Check if server is running"
+    echo "  test [args]        Run the test suite (passes args to jest)"
+    echo "  logs               Show server logs"
+    echo "  help, --help       Show this help message"
+    echo ""
+    echo "Examples:"
+    echo "  $0 start --background   # Start server in background"
+    echo "  $0 status               # Check if running"
+    echo "  $0 test --watch         # Run tests in watch mode"
+    echo "  $0 logs                 # View recent logs"
+    echo ""
+    echo "Files:"
+    echo "  PID file: $PID_FILE"
+    echo "  Log file: $LOG_FILE"
+}
+
+# Main command handler
+main() {
+    local command="${1:-help}"
+    shift || true
+
+    case "$command" in
+        start)
+            cmd_start "$@"
+            ;;
+        stop)
+            cmd_stop
+            ;;
+        restart)
+            cmd_restart
+            ;;
+        status)
+            cmd_status
+            ;;
+        test)
+            cmd_test "$@"
+            ;;
+        logs)
+            cmd_logs
+            ;;
+        help|--help|-h)
+            cmd_help
+            ;;
+        *)
+            print_error "Unknown command: $command"
+            echo ""
+            cmd_help
+            exit 1
+            ;;
+    esac
+}
+
+# Run main
+main "$@"


### PR DESCRIPTION
## Summary

- Add `scripts/dev-server.sh` for managing dev server lifecycle
- Add npm script shortcuts for common operations
- Add PID and log file tracking
- Update CLAUDE.md with documentation

## Commands

### npm scripts
```bash
npm run dev:start    # Start server in background
npm run dev:stop     # Stop the server
npm run dev:status   # Check if running
npm run dev:restart  # Restart server
npm run dev:logs     # View logs
```

### Direct script usage
```bash
./scripts/dev-server.sh start --background
./scripts/dev-server.sh stop
./scripts/dev-server.sh status
./scripts/dev-server.sh logs
./scripts/dev-server.sh test
```

## Features

- **PID tracking**: Server PID stored in `.dev-server.pid`
- **Log capture**: Output saved to `.dev-server.log` when running in background
- **Graceful shutdown**: SIGTERM with fallback to SIGKILL after timeout
- **Stale PID cleanup**: Automatically cleans up orphaned PID files
- **Colored output**: Status messages with colors for clarity
- **Help system**: `--help` shows usage information

## Test Plan

- [ ] Run `npm run dev:start` - verify server starts in background
- [ ] Run `npm run dev:status` - verify shows running with PID
- [ ] Run `npm run dev:logs` - verify shows server output
- [ ] Run `npm run dev:stop` - verify server stops
- [ ] Run `npm run dev:status` - verify shows not running
- [ ] Run tests: `npm test -- --testPathPattern="dev-server"`

Closes #13